### PR TITLE
FD-119445 dayjs locales regex fix

### DIFF
--- a/src/plugin/customParseFormat/index.js
+++ b/src/plugin/customParseFormat/index.js
@@ -10,6 +10,7 @@ const match1to2 = /\d\d?/ // 0 - 99
 const matchSigned = /[+-]?\d+/ // -inf - inf
 const matchOffset = /[+-]\d\d:?(\d\d)?|Z/ // +00:00 -00:00 +0000 or -0000 +00 or Z
 const matchWord = /\d*[^-_:/,()\s\d]+/ // Word
+const matchWordAndNumber = /\d*[^-_:/,()\s]+/ // Word and Number
 
 let locale = {}
 
@@ -97,7 +98,7 @@ const expressions = {
   }],
   M: [match1to2, addInput('month')],
   MM: [match2, addInput('month')],
-  MMM: [matchWord, function (input) {
+  MMM: [matchWordAndNumber, function (input) {
     const months = getLocalePart('months')
     const monthsShort = getLocalePart('monthsShort')
     const matchIndex = (monthsShort || months.map(_ => _.slice(0, 3))).indexOf(input) + 1

--- a/test/plugin/customParseFormat.test.js
+++ b/test/plugin/customParseFormat.test.js
@@ -4,6 +4,7 @@ import dayjs from '../../src'
 import '../../src/locale/ru'
 import uk from '../../src/locale/uk'
 import '../../src/locale/zh-cn'
+import '../../src/locale/vi'
 import customParseFormat from '../../src/plugin/customParseFormat'
 import advancedFormat from '../../src/plugin/advancedFormat'
 import localizedFormats from '../../src/plugin/localizedFormat'
@@ -293,6 +294,11 @@ describe('month function locale', () => {
     const input = '08 февр. 2020'
     const format = 'DD MMM YYYY'
     expect(dayjs(input, format, 'ru').valueOf()).toBe(moment(input, format, 'ru').valueOf())
+  })
+  it('MMM (vietnamese)', () => {
+    const input = '01 Th09 2019'
+    const format = 'DD MMM YYYY'
+    expect(dayjs(input, format, 'vi').isValid()).toBe(true)
   })
 })
 


### PR DESCRIPTION
Some months in other languages has number as well. So updating the regex accordingly if format is 'MMM'